### PR TITLE
Fix Spanish typo in checklist

### DIFF
--- a/project_checklist.md
+++ b/project_checklist.md
@@ -28,7 +28,7 @@
 * [ ] Crear `pyproject.toml` limpio y reproducible
 * [ ] Crear `Dockerfile` optimizado (basado en Python slim o similar)
 * [ ] Crear `.dockerignore`
-* [ ] Agregar `entrypoint.sh` (si es últil para inicialización)
+* [ ] Agregar `entrypoint.sh` (si es útil para inicialización)
 * [ ] Probar build de Docker e iniciar contenedor correctamente
 * [ ] Probar contenedor desde otra máquina (usuario final sin dev tools)
 


### PR DESCRIPTION
## Summary
- correct spelling in Docker/entrypoint checklist item

## Testing
- `grep -n útil project_checklist.md`

------
https://chatgpt.com/codex/tasks/task_e_68437fb669188322a07e0fbffb66877d