### PR TITLE
Fix wrong keyword argument in MCP agent

### DIFF
--- a/rag_app/agents/mcp_agent.py
+++ b/rag_app/agents/mcp_agent.py
@@ -10,10 +10,6 @@ def answer_with_mcp(query: str) -> str:
     """
     logger.info("🧠 No relevant chunks found — triggering MCP agent.")
     
-    # You may send only the query or wrap it in a custom instruction.
-    # The generate_answer function expects context_chunks as the second
-    # argument. Previously the call used the wrong keyword "chunks",
-    # which caused a TypeError.
     answer = generate_answer(query=query, context_chunks=[])
     
     logger.info("✅ MCP agent generated a fallback answer.")

--- a/rag_app/agents/mcp_agent.py
+++ b/rag_app/agents/mcp_agent.py
@@ -10,8 +10,11 @@ def answer_with_mcp(query: str) -> str:
     """
     logger.info("🧠 No relevant chunks found — triggering MCP agent.")
     
-    # Puedes mandar solo el query o envolverlo en una instrucción especial
-    answer = generate_answer(query=query, chunks=[])
+    # You may send only the query or wrap it in a custom instruction.
+    # The generate_answer function expects context_chunks as the second
+    # argument. Previously the call used the wrong keyword "chunks",
+    # which caused a TypeError.
+    answer = generate_answer(query=query, context_chunks=[])
     
     logger.info("✅ MCP agent generated a fallback answer.")
     return answer


### PR DESCRIPTION
## Summary
- fix call to `generate_answer` in `mcp_agent`
- translate comments in `mcp_agent` to English

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rag_app' and 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68437ecf1420832298c255e99d8a1234