### PR TITLE
Fix DOCUMENTS_PATH in indexer tests

### DIFF
--- a/rag_app/tests/test_indexer.py
+++ b/rag_app/tests/test_indexer.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from rag_app.ingestion import indexer
 
-DOCUMENTS_PATH = Path("data/documents.json")
+DOCUMENTS_PATH = Path("rag_app/data/documents.json")
 
 class TestIndexer(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- use the same documents path in tests as the indexer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rag_app')*

------
https://chatgpt.com/codex/tasks/task_e_68437fbbf65483229820d1a8b4cfd83c