### PR TITLE
Patch generator test with mock

### DIFF
--- a/rag_app/tests/test_generator.py
+++ b/rag_app/tests/test_generator.py
@@ -1,7 +1,39 @@
 # rag_app/tests/test_generator.py
 
+import os
+import sys
+import types
 import unittest
-from rag_app.generator.generator import generate_answer
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+try:
+    from rag_app.generator import generator
+except ModuleNotFoundError:
+    # Create minimal stubs if optional dependencies are missing
+    fake_genai = types.ModuleType("google.generativeai")
+    fake_genai.configure = lambda *args, **kwargs: None
+
+    class FakeModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def generate_content(self, prompt):
+            pass
+
+    fake_genai.GenerativeModel = FakeModel
+    sys.modules.setdefault("google", types.ModuleType("google"))
+    sys.modules["google.generativeai"] = fake_genai
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+    os.environ.setdefault("GEMINI_API_KEY", "dummy")
+
+    from rag_app.generator import generator
+
 
 class TestGenerator(unittest.TestCase):
     def test_generate_answer(self):
@@ -10,9 +42,14 @@ class TestGenerator(unittest.TestCase):
             "LexisNexis is a global provider of legal, regulatory and business information.",
             "They offer AI-powered tools like Lexis+ to support litigation and research."
         ]
-        answer = generate_answer(query, context)
-        print("\n📤 Generated answer:\n", answer)
-        self.assertTrue(isinstance(answer, str) and len(answer) > 0)
+
+        mock_response = MagicMock()
+        mock_response.text = "Mocked answer"
+
+        with patch.object(generator.model, "generate_content", return_value=mock_response):
+            answer = generator.generate_answer(query, context)
+
+        self.assertEqual(answer, "Mocked answer")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fix importability by creating empty package file
- patch Gemini calls in `test_generator.py` with a mocked object to avoid external dependencies

## Testing
- `pytest rag_app/tests/test_generator.py -q`
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68437fc07118832292d00a42ed262c39