### PR TITLE
Implement FastAPI backend and HTML demo page

### DIFF
--- a/rag_app/__init__.py
+++ b/rag_app/__init__.py
@@ -1,0 +1,5 @@
+"""LEXIS RAG package."""
+
+from .app.main import app
+
+__all__ = ["app"]

--- a/rag_app/app/main.py
+++ b/rag_app/app/main.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from rag_app.retriever.retriever import retrieve_relevant_chunks
+from rag_app.generator.generator import generate_answer
+from rag_app.agents.mcp_agent import answer_with_mcp
+from rag_app.ingestion.indexer import index_url
+
+app = FastAPI(title="LEXIS RAG API")
+
+static_dir = Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+class QueryRequest(BaseModel):
+    query: str
+
+class QueryResponse(BaseModel):
+    answer: str
+
+
+class IndexRequest(BaseModel):
+    url: str
+
+@app.get("/", response_class=FileResponse)
+def read_index():
+    return static_dir / "index.html"
+
+@app.post("/ask", response_model=QueryResponse)
+def ask_question(req: QueryRequest):
+    chunks = retrieve_relevant_chunks(req.query, top_k=3)
+    if not chunks:
+        answer = answer_with_mcp(req.query)
+    else:
+        answer = generate_answer(req.query, chunks)
+    return QueryResponse(answer=answer)
+
+
+@app.post("/index")
+def add_url(req: IndexRequest):
+    doc_ids = index_url(req.url)
+    return {"documents_indexed": len(doc_ids)}

--- a/rag_app/app/static/index.html
+++ b/rag_app/app/static/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>LEXIS RAG Demo</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 2em; }
+        #response { margin-top: 1em; white-space: pre-wrap; }
+    </style>
+</head>
+<body>
+    <h1>LEXIS RAG Demo</h1>
+    <input type="text" id="query" placeholder="Ask a question" size="50" />
+    <button onclick="ask()">Ask</button>
+    <div id="response"></div>
+    <script>
+        async function ask() {
+            const query = document.getElementById('query').value;
+            const respDiv = document.getElementById('response');
+            respDiv.textContent = 'Loading...';
+            const res = await fetch('/ask', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ query })
+            });
+            const data = await res.json();
+            respDiv.textContent = data.answer || 'No answer';
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement basic FastAPI app with `/` HTML page, `/ask` question endpoint and `/index` for URL ingestion
- expose app in package `__init__`
- add a minimal HTML frontend for quick queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843840f6320832294983042915dfec4