### PR TITLE
Support system prompt in answer generation

### DIFF
--- a/rag_app/generator/generator.py
+++ b/rag_app/generator/generator.py
@@ -35,6 +35,9 @@ def generate_answer(query: str, chunks: List[str], system_prompt: Optional[str] 
     {query}
     """
 
+    if system_prompt:
+        prompt = f"{system_prompt}\n\n{prompt}"
+
     try:
         response = model.generate_content(prompt)
         answer = response.text.strip()

--- a/rag_app/tests/test_generator.py
+++ b/rag_app/tests/test_generator.py
@@ -51,5 +51,20 @@ class TestGenerator(unittest.TestCase):
 
         self.assertEqual(answer, "Mocked answer")
 
+    def test_generate_answer_with_system_prompt(self):
+        query = "What is LexisNexis known for?"
+        context = ["LexisNexis provides legal information."]
+        system_prompt = "Answer in pirate style."
+
+        mock_response = MagicMock()
+        mock_response.text = "Arr! Mocked answer"
+
+        with patch.object(generator.model, "generate_content", return_value=mock_response) as mock_generate:
+            answer = generator.generate_answer(query, context, system_prompt=system_prompt)
+
+        called_prompt = mock_generate.call_args[0][0]
+        self.assertTrue(called_prompt.startswith(system_prompt))
+        self.assertEqual(answer, "Arr! Mocked answer")
+
 if __name__ == "__main__":
     unittest.main()

--- a/rag_app/tests/test_mcp_agent.py
+++ b/rag_app/tests/test_mcp_agent.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+try:
+    from rag_app.agents import mcp_agent
+except ModuleNotFoundError:
+    # Minimal stubs for optional dependencies
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+    os.environ.setdefault("GEMINI_API_KEY", "dummy")
+
+    from rag_app.agents import mcp_agent
+
+
+class TestMcpAgent(unittest.TestCase):
+    def test_answer_with_mcp_uses_system_prompt(self):
+        query = "Who are you?"
+        with patch("rag_app.agents.mcp_agent.generate_answer", return_value="hi") as mock_gen:
+            result = mcp_agent.answer_with_mcp(query, persist=False)
+
+        self.assertEqual(result, "hi")
+        mock_gen.assert_called_once()
+        kwargs = mock_gen.call_args.kwargs
+        self.assertEqual(kwargs.get("system_prompt"), mcp_agent.MCP_SYSTEM_PROMPT)
+        self.assertEqual(kwargs.get("chunks"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow passing a custom `system_prompt` to `generate_answer`
- ensure prompt prefix is included when used
- add tests for custom prompt support
- test that `answer_with_mcp` passes the MCP prompt

## Testing
- `pytest rag_app/tests/test_generator.py rag_app/tests/test_mcp_agent.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685940ad68ac83228392353cb83342a5